### PR TITLE
FIX for manufacturer page (getParentCategory)

### DIFF
--- a/theme/source/application/views/mobile/tpl/page/list/list.tpl
+++ b/theme/source/application/views/mobile/tpl/page/list/list.tpl
@@ -1,5 +1,8 @@
 [{assign var="actCategory" value=$oView->getActiveCategory()}]
-[{assign var="parentCategory" value=$actCategory->getParentCategory()}]
+[{assign var="listType" value=$oView->getListType()}]
+[{if $listType != 'manufacturer'}]
+    [{assign var="parentCategory" value=$actCategory->getParentCategory()}]
+[{/if}]
 
 [{capture append="oxidBlock_content"}]
 


### PR DESCRIPTION
If you go to a manufacturer page in the mobile theme, you will get an exception with the content "Function 'getParentCategory' does not exist or is not accessible! (oxManufacturer)". So check in the template if we are on a manufacturer page. If we are on a manufacturer page, don't call getParentCategory, because this function doesn't exist in the oxmanufacturer class.
