### PR TITLE
duplicate funtionality (from oeThemeSwitcherAList::getViewId) to prevent infinity loop.

### DIFF
--- a/module/source/modules/oe/oethemeswitcher/controllers/oethemeswitchermanufacturerlist.php
+++ b/module/source/modules/oe/oethemeswitcher/controllers/oethemeswitchermanufacturerlist.php
@@ -34,8 +34,7 @@ class oeThemeSwitcherManufacturerList extends oeThemeSwitcherManufacturerList_pa
      */
     public function getViewId()
     {
-        $oUBase = oxNew('aList');
-        $sViewId = $oUBase->getViewId();
+        $sViewId = parent::getViewId();
         $sViewId .= $this->getConfig()->oeThemeSwitcherGetActiveThemeId();
 
         return $sViewId;

--- a/module/source/modules/oe/oethemeswitcher/controllers/oethemeswitchervendorlist.php
+++ b/module/source/modules/oe/oethemeswitcher/controllers/oethemeswitchervendorlist.php
@@ -31,8 +31,7 @@ class oeThemeSwitcherVendorList extends oeThemeSwitcherVendorList_parent
      */
     public function getViewId()
     {
-        $oUBase = oxNew('aList');
-        $sViewId = $oUBase->getViewId();
+        $sViewId = parent::getViewId();
         $sViewId .= $this->getConfig()->oeThemeSwitcherGetActiveThemeId();
 
         return $sViewId;


### PR DESCRIPTION
duplicate funtionality (from oeThemeSwitcherAList::getViewId) to prevent infinity loop.
